### PR TITLE
Added currency_type to Invoice model

### DIFF
--- a/cryptobot/models/__init__.py
+++ b/cryptobot/models/__init__.py
@@ -41,6 +41,7 @@ class Invoice:
     status: Status
     hash: str
     asset: Asset
+    currency_type: str
     amount: str
     pay_url: str
     description: str = None


### PR DESCRIPTION
CryptoBot has added a `currency_type` field to the invoices, causing our payments workflow to fail. We need to update this.