### PR TITLE
hotfix over invoice dataclass

### DIFF
--- a/cryptobot/models/__init__.py
+++ b/cryptobot/models/__init__.py
@@ -77,6 +77,8 @@ class Invoice:
     fee: str = None
     pay_url: str = None
     usd_rate: str = None
+    mini_app_invoice_url: str = None
+    web_app_invoice_url: str = None
 
 
 @dataclass


### PR DESCRIPTION
Hotfix adding two new fields in the invoice dataclass:  mini_app_invoice_url and web_app_invoice_url to complain with the api of crypt.bot