### PR TITLE
feat: add swap_to parameter to create_invoice method

### DIFF
--- a/cryptobot/_sync/client.py
+++ b/cryptobot/_sync/client.py
@@ -65,6 +65,7 @@ class CryptoBotClient:
         allow_comments: bool = None,
         allow_anonymous: bool = None,
         expires_in: int = None,
+        swap_to: str = None,
     ) -> Invoice:
         """Create a new invoice"""
         data = {
@@ -77,6 +78,7 @@ class CryptoBotClient:
             "allow_comments": allow_comments,
             "allow_anonymous": allow_anonymous,
             "expires_in": expires_in,
+            "swap_to": swap_to,
         }
         # TODO: Check the minimum amount
 


### PR DESCRIPTION
CryptoBot introduced a swap_to field to allow "creating invoices with automatic conversion of the cryptocurrency paid by the user into your preferred asset":

https://t.me/CryptoBotEN/322

API docs:
http://help.crypt.bot/crypto-pay-api#createInvoice