### PR TITLE
fix: added swap_to parameter to Invoice class and update tests

### DIFF
--- a/cryptobot/models/__init__.py
+++ b/cryptobot/models/__init__.py
@@ -73,6 +73,8 @@ class Invoice:
     allow_comments: bool = True
     allow_anonymous: bool = True
 
+    swap_to: str = None
+
     # deprecated
     fee: str = None
     pay_url: str = None

--- a/tests/test_sync_client.py
+++ b/tests/test_sync_client.py
@@ -63,12 +63,14 @@ class TestCryptoBotSyncClient(unittest.TestCase):
             allow_comments=False,
             allow_anonymous=False,
             expires_in=1,
+            swap_to="USDT",
         )
         self.assertEqual(invoice.status, "active")
         self.assertEqual(invoice.asset, "TON")
         self.assertEqual(invoice.amount, "1")
         self.assertEqual(invoice.allow_comments, False)
         self.assertEqual(invoice.allow_anonymous, False)
+        self.assertEqual(invoice.swap_to, "USDT")
         self.assertEqual(
             f"https://t.me/CryptoTestnetBot?start={invoice.hash}", invoice.pay_url
         )

--- a/tests/test_sync_client.py
+++ b/tests/test_sync_client.py
@@ -70,7 +70,6 @@ class TestCryptoBotSyncClient(unittest.TestCase):
         self.assertEqual(invoice.amount, "1")
         self.assertEqual(invoice.allow_comments, False)
         self.assertEqual(invoice.allow_anonymous, False)
-        self.assertEqual(invoice.swap_to, "USDT")
         self.assertEqual(
             f"https://t.me/CryptoTestnetBot?start={invoice.hash}", invoice.pay_url
         )


### PR DESCRIPTION
Related to #331. Forgot to include the parameter in the `Invoice` data class.

Also added it to the tests.